### PR TITLE
Compile with no implicit returns.

### DIFF
--- a/src/analyze/document-analyzer/html/definition/definition-for-html-attr.ts
+++ b/src/analyze/document-analyzer/html/definition/definition-for-html-attr.ts
@@ -20,4 +20,5 @@ export function definitionForHtmlAttr(htmlAttr: HtmlNodeAttr, { htmlStore, docum
 			target: target.declaration
 		};
 	}
+	return;
 }

--- a/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr-assignment.ts
+++ b/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr-assignment.ts
@@ -145,6 +145,7 @@ function validateHtmlAttrAssignmentRules(htmlAttr: HtmlNodeAttr, typeB: SimpleTy
 			}
 			break;
 	}
+	return;
 }
 
 function validateHtmlAttrSlotAssignment(htmlAttr: HtmlNodeAttr, { document, htmlStore, config, program }: LitAnalyzerRequest): LitHtmlDiagnostic[] | undefined {
@@ -239,6 +240,7 @@ function validateHtmlAttrAssignmentTypes(htmlAttr: HtmlNodeAttr, { typeA, typeB 
 			}
 		];
 	}
+	return;
 }
 
 function validateStringifiedAssignment(
@@ -389,6 +391,7 @@ function validateStringifiedAssignment(
 			];
 		}
 	}
+	return;
 }
 
 function validateHtmlAttrDirectiveAssignment(htmlAttr: HtmlNodeAttr, { typeA, typeB }: { typeA: SimpleType; typeB: SimpleType }, request: LitAnalyzerRequest): LitHtmlDiagnostic[] | undefined {

--- a/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr.ts
+++ b/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr.ts
@@ -121,4 +121,5 @@ function findSuggestedTarget(name: string, ...tests: Iterable<HtmlAttrTarget>[])
 			return match;
 		}
 	}
+	return;
 }

--- a/src/analyze/document-analyzer/html/lit-html-document-analyzer.ts
+++ b/src/analyze/document-analyzer/html/lit-html-document-analyzer.ts
@@ -76,6 +76,7 @@ export class LitHtmlDocumentAnalyzer {
 		} else if (isHTMLAttr(hit)) {
 			return definitionForHtmlAttr(hit, request);
 		}
+		return;
 	}
 
 	getRenameInfoAtOffset(document: HtmlDocument, offset: number, request: LitAnalyzerRequest): LitRenameInfo | undefined {
@@ -92,6 +93,7 @@ export class LitHtmlDocumentAnalyzer {
 				target: hit
 			};
 		}
+		return;
 	}
 
 	getRenameLocationsAtOffset(document: HtmlDocument, offset: number, request: LitAnalyzerRequest): LitRenameLocation[] {
@@ -109,6 +111,7 @@ export class LitHtmlDocumentAnalyzer {
 		if (isHTMLAttr(hit)) {
 			return quickInfoForHtmlAttr(hit, request);
 		}
+		return;
 	}
 
 	getOutliningSpans(document: HtmlDocument): LitOutliningSpan[] {

--- a/src/analyze/lit-analyzer.ts
+++ b/src/analyze/lit-analyzer.ts
@@ -64,6 +64,7 @@ export class LitAnalyzer {
 		} else if (document instanceof HtmlDocument) {
 			return this.litHtmlDocumentAnalyzer.getDefinitionAtOffset(document, offset, request);
 		}
+		return;
 	}
 
 	getQuickInfoAtPosition(file: SourceFile, position: number): LitQuickInfo | undefined {
@@ -79,6 +80,7 @@ export class LitAnalyzer {
 		} else if (document instanceof HtmlDocument) {
 			return this.litHtmlDocumentAnalyzer.getQuickInfoAtOffset(document, offset, request);
 		}
+		return;
 	}
 
 	getRenameInfoAtPosition(file: SourceFile, position: number): LitRenameInfo | undefined {
@@ -110,6 +112,7 @@ export class LitAnalyzer {
 				}
 			}
 		}
+		return;
 	}
 
 	getRenameLocationsAtPosition(file: SourceFile, position: number): LitRenameLocation[] {
@@ -140,6 +143,7 @@ export class LitAnalyzer {
 		if (document instanceof HtmlDocument) {
 			return this.litHtmlDocumentAnalyzer.getClosingTagAtOffset(document, offset);
 		}
+		return;
 	}
 
 	getCompletionDetailsAtPosition(file: SourceFile, position: number, name: string): LitCompletionDetails | undefined {
@@ -153,6 +157,7 @@ export class LitAnalyzer {
 		} else if (document instanceof HtmlDocument) {
 			return this.litHtmlDocumentAnalyzer.getCompletionDetailsAtOffset(document, offset, name, request);
 		}
+		return;
 	}
 
 	getCompletionsAtPosition(file: SourceFile, position: number): LitCompletion[] | undefined {
@@ -169,6 +174,7 @@ export class LitAnalyzer {
 		} else if (document instanceof HtmlDocument) {
 			return this.litHtmlDocumentAnalyzer.getCompletionsAtOffset(document, offset, request);
 		}
+		return;
 	}
 
 	getDiagnosticsInFile(file: SourceFile): LitDiagnostic[] {

--- a/src/analyze/parse/document/text-document/html-document/html-document.ts
+++ b/src/analyze/parse/document/text-document/html-document/html-document.ts
@@ -22,6 +22,7 @@ export class HtmlDocument extends TextDocument {
 
 				return node;
 			}
+			return;
 		});
 	}
 
@@ -43,6 +44,7 @@ export class HtmlDocument extends TextDocument {
 
 		const htmlAttr = this.htmlAttrNameAtOffset(offset);
 		if (htmlAttr != null) return htmlAttr;
+		return;
 	}
 
 	findAttr(test: (node: HtmlNodeAttr) => boolean): HtmlNodeAttr | undefined {
@@ -50,12 +52,14 @@ export class HtmlDocument extends TextDocument {
 			for (const attr of node.attributes) {
 				if (test(attr)) return attr;
 			}
+			return;
 		});
 	}
 
 	findNode(test: (node: HtmlNode) => boolean): HtmlNode | undefined {
 		return this.mapFindOne(node => {
 			if (test(node)) return node;
+			return;
 		});
 	}
 
@@ -81,6 +85,7 @@ export class HtmlDocument extends TextDocument {
 				const found = innerTest(childNode);
 				if (found != null) return found;
 			}
+			return;
 		}
 
 		for (const rootNode of this.rootNodes || []) {
@@ -89,5 +94,6 @@ export class HtmlDocument extends TextDocument {
 				return found;
 			}
 		}
+		return;
 	}
 }

--- a/src/analyze/parse/document/virtual-document/virtual-document.ts
+++ b/src/analyze/parse/document/virtual-document/virtual-document.ts
@@ -25,6 +25,7 @@ export function textPartsToRanges(parts: (Expression | string)[]): Range[] {
 			} else {
 				offset += p.getText().length + 3;
 			}
+			return;
 		})
 		.filter((r): r is Range => r != null);
 }

--- a/src/analyze/util/iterable-util.ts
+++ b/src/analyze/util/iterable-util.ts
@@ -26,6 +26,7 @@ export function iterableFind<T>(iterable: Iterable<T>, match: (item: T) => boole
 			return item;
 		}
 	}
+	return;
 }
 
 export function* iterableUnique<T>(iterable: Iterable<T>, on: (item: T) => any): Iterable<T> {
@@ -44,6 +45,7 @@ export function iterableFirst<T>(iterable: Iterable<T>): T | undefined {
 	for (const item of iterable) {
 		return item;
 	}
+	return;
 }
 
 export function iterableDefined<T>(iterable: (T | undefined | null)[]): T[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"noImplicitThis": true,
 		"noImplicitAny": true,
+		"noImplicitReturns": true,
 		"skipLibCheck": true,
 		"declaration": true,
 		"declarationMap": true


### PR DESCRIPTION
I'm prototyping using this module as a plugin in https://github.com/bazelbuild/rules_typescript

As part of pulling it into google's internal repo for the prototyping, it has to compile with google's internal tsconfig, which includes noImplicitReturns. I'm not sure that it's an improvement in legibility, so if you don't want to merge this that's fine, we can use a patch set on top.