### PR TITLE
Add a config option dontSuggestConfigChanges

### DIFF
--- a/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr.ts
+++ b/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr.ts
@@ -49,8 +49,14 @@ export function validateHtmlAttr(htmlAttr: HtmlNodeAttr, request: LitAnalyzerReq
 		const suggestion = (() => {
 			switch (htmlAttr.kind) {
 				case HtmlNodeAttrKind.EVENT_LISTENER:
+					if (request.config.dontSuggestConfigChanges) {
+						return `Please consider adding a '@event' tag to the jsdoc on a component class`;
+					}
 					return `Please consider adding a '@event' tag to the jsdoc on a component class, adding it to 'globalEvents' or removing 'checkUnknownEvents'.`;
 				case HtmlNodeAttrKind.PROPERTY:
+					if (request.config.dontSuggestConfigChanges) {
+						return undefined;
+					}
 					return tagIsBuiltIn
 						? `This is a built in tag. Please consider using 'skipUnknownProperties'.`
 						: tagIsFromLibrary
@@ -60,6 +66,9 @@ export function validateHtmlAttr(htmlAttr: HtmlNodeAttr, request: LitAnalyzerReq
 						: `Please consider adding 'skipUnknownProperties' to the plugin config.`;
 				case HtmlNodeAttrKind.BOOLEAN_ATTRIBUTE:
 				case HtmlNodeAttrKind.ATTRIBUTE:
+					if (request.config.dontSuggestConfigChanges) {
+						return `Please consider using a data-* attribute.`;
+					}
 					return tagIsBuiltIn
 						? `This is a built in tag. Please consider using a 'data-*' attribute, adding the attribute to 'globalAttributes' or using 'skipUnknownAttributes'.`
 						: tagIsFromLibrary
@@ -85,7 +94,7 @@ export function validateHtmlAttr(htmlAttr: HtmlNodeAttr, request: LitAnalyzerReq
 		return [
 			{
 				kind: LitHtmlDiagnosticKind.UNKNOWN_TARGET,
-				message: `Unknown ${existingKind} "${htmlAttr.name}"${suggestedMemberName != null ? `. Did you mean '${suggestedMemberName}'?` : ""}`,
+				message: `Unknown ${existingKind} '${htmlAttr.name}'${suggestedMemberName != null ? `. Did you mean '${suggestedMemberName}'?` : ""}`,
 				suggestion,
 				severity: "warning",
 				location: { document, ...htmlAttr.location.name },

--- a/src/analyze/lit-analyzer-config.ts
+++ b/src/analyze/lit-analyzer-config.ts
@@ -19,6 +19,8 @@ export interface LitAnalyzerConfig {
 	skipTypeChecking: boolean;
 	skipMissingImports: boolean;
 
+	dontSuggestConfigChanges: boolean;
+
 	globalTags: string[];
 	globalAttributes: string[];
 	globalEvents: string[];
@@ -37,6 +39,7 @@ export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAna
 		format: {
 			disable: userOptions.format != null ? userOptions.format.disable : undefined || false
 		},
+		dontSuggestConfigChanges: userOptions.dontSuggestConfigChanges || false,
 		// Template tags
 		htmlTemplateTags: userOptions.htmlTemplateTags || ["html", "raw"],
 		cssTemplateTags: userOptions.cssTemplateTags || ["css"],


### PR DESCRIPTION
This one's pretty obscure for most people, so I'm not sure it's even worth documenting in the README. It's useful in our case because in the internal build system at google we want to use a single canonical configuration for the plugin, in order for things to be simpler and more consistent.

As a result, it'd be nice if we could configure the plugin to not suggest making configuration changes, because changes in configuration would be rare and global, so not a reasonable response to any single error.

Also made a handful of minor changes to message wording (to use consistent quote marks, that sort of thing).