### PR TITLE
Support both the parse5@5.0 and the @4.0 location info APIs

### DIFF
--- a/src/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
+++ b/src/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
@@ -1,5 +1,5 @@
 import { Range } from "../../../../../types/range";
-import { IP5NodeAttr, IP5TagNode } from "../parse-html-p5/parse-html-types";
+import { IP5NodeAttr, IP5TagNode, getSourceLocation } from "../parse-html-p5/parse-html-types";
 import { HtmlNodeAttrAssignment, HtmlNodeAttrAssignmentKind } from "../../../../../types/html-node/html-node-attr-assignment-types";
 import { HtmlNodeAttr } from "../../../../../types/html-node/html-node-attr-types";
 import { ParseHtmlContext } from "./parse-html-context";
@@ -47,7 +47,7 @@ export function parseHtmlAttrAssignment(p5Node: IP5TagNode, p5Attr: IP5NodeAttr,
 }
 
 function getAssignmentLocation(p5Node: IP5TagNode, p5Attr: IP5NodeAttr, htmlAttr: HtmlNodeAttr, context: ParseHtmlContext): Range | undefined {
-	const htmlAttrLocation = (p5Node.sourceCodeLocation.startTag.attrs || {})[p5Attr.name];
+	const htmlAttrLocation = (getSourceLocation(p5Node)!.startTag.attrs || {})[p5Attr.name];
 	if (htmlAttrLocation == null) return undefined;
 
 	const nameEndOffset = htmlAttr.location.name.end;

--- a/src/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attribute.ts
+++ b/src/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attribute.ts
@@ -1,7 +1,7 @@
 import { LIT_HTML_BOOLEAN_ATTRIBUTE_MODIFIER, LIT_HTML_EVENT_LISTENER_ATTRIBUTE_MODIFIER, LIT_HTML_PROP_ATTRIBUTE_MODIFIER } from "../../../../../constants";
 import { HtmlNodeAttr, HtmlNodeAttrKind, IHtmlNodeAttrBase, IHtmlNodeAttrSourceCodeLocation } from "../../../../../types/html-node/html-node-attr-types";
 import { parseLitAttrName } from "../../../../../util/general-util";
-import { IP5NodeAttr, IP5TagNode } from "../parse-html-p5/parse-html-types";
+import { IP5NodeAttr, IP5TagNode, getSourceLocation } from "../parse-html-p5/parse-html-types";
 import { parseHtmlAttrAssignment } from "./parse-html-attr-assignment";
 import { ParseHtmlAttrContext } from "./parse-html-attr-context";
 
@@ -58,7 +58,7 @@ function makeHtmlAttrLocation(p5Node: IP5TagNode, p5Attr: IP5NodeAttr, context: 
 	// Parse5 lowercases source code location attr keys but doesnt lowercase the attr name when it comes to svg.
 	// It would be correct not to lowercase the attr names because svg is case sensitive
 	const sourceCodeLocationName = `${p5Attr.prefix || ""}${(p5Attr.prefix && ":") || ""}${p5Attr.name}`.toLowerCase();
-	const htmlAttrLocation = (p5Node.sourceCodeLocation.startTag.attrs || {})[sourceCodeLocationName];
+	const htmlAttrLocation = (getSourceLocation(p5Node)!.startTag.attrs || {})[sourceCodeLocationName];
 	const start = htmlAttrLocation.startOffset;
 	const end = htmlAttrLocation.endOffset;
 	return {

--- a/src/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-node.ts
+++ b/src/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-node.ts
@@ -1,7 +1,7 @@
 import { TS_IGNORE_FLAG } from "../../../../../constants";
 import { HtmlNode, HtmlNodeKind, IHtmlNodeBase, IHtmlNodeSourceCodeLocation } from "../../../../../types/html-node/html-node-types";
 import { isCommentNode, isTagNode } from "../parse-html-p5/parse-html";
-import { IP5TagNode, P5Node } from "../parse-html-p5/parse-html-types";
+import { IP5TagNode, P5Node, getSourceLocation } from "../parse-html-p5/parse-html-types";
 import { parseHtmlNodeAttrs } from "./parse-html-attribute";
 import { ParseHtmlContext } from "./parse-html-context";
 
@@ -45,7 +45,7 @@ export function parseHtmlNodes(p5Nodes: P5Node[], parent: HtmlNode | undefined, 
  */
 export function parseHtmlNode(p5Node: IP5TagNode, parent: HtmlNode | undefined, context: ParseHtmlContext): HtmlNode | undefined {
 	// `sourceCodeLocation` will be undefined if the element was implicitly created by the parser.
-	if (p5Node.sourceCodeLocation == null) return undefined;
+	if (getSourceLocation(p5Node) == null) return undefined;
 
 	const htmlNodeBase: IHtmlNodeBase = {
 		tagName: p5Node.tagName.toLowerCase(),
@@ -75,7 +75,7 @@ export function parseHtmlNode(p5Node: IP5TagNode, parent: HtmlNode | undefined, 
  */
 function isSelfClosed(p5Node: IP5TagNode, context: ParseHtmlContext) {
 	const isEmpty = p5Node.childNodes == null || p5Node.childNodes.length === 0;
-	const isSelfClosed = p5Node.sourceCodeLocation.startTag.endOffset === p5Node.sourceCodeLocation.endOffset;
+	const isSelfClosed = getSourceLocation(p5Node)!.startTag.endOffset === getSourceLocation(p5Node)!.endOffset;
 	return isEmpty && isSelfClosed;
 }
 
@@ -85,7 +85,7 @@ function isSelfClosed(p5Node: IP5TagNode, context: ParseHtmlContext) {
  * @param context
  */
 function makeHtmlNodeLocation(p5Node: IP5TagNode, context: ParseHtmlContext): IHtmlNodeSourceCodeLocation {
-	const loc = p5Node.sourceCodeLocation;
+	const loc = getSourceLocation(p5Node)!;
 
 	return {
 		start: loc.startOffset,

--- a/src/analyze/parse/document/text-document/html-document/parse-html-p5/parse-html-types.ts
+++ b/src/analyze/parse/document/text-document/html-document/parse-html-p5/parse-html-types.ts
@@ -28,7 +28,6 @@ export interface IP5TextNode extends IP5NodeBase {
 	nodeName: "#text";
 	value: string;
 	parentNode: P5Node;
-	sourceCodeLocation: IP5BaseSourceCodeLocation;
 }
 
 export interface IP5CommentNode extends IP5NodeBase {
@@ -36,7 +35,6 @@ export interface IP5CommentNode extends IP5NodeBase {
 	value: string;
 	data?: string;
 	parentNode: P5Node;
-	sourceCodeLocation: IP5BaseSourceCodeLocation;
 }
 
 export interface IP5TagNode extends IP5NodeBase {
@@ -46,10 +44,22 @@ export interface IP5TagNode extends IP5NodeBase {
 	namespaceURI: string;
 	childNodes?: [];
 	parentNodes: P5Node;
-	sourceCodeLocation: IP5BaseSourceCodeLocation & {
-		startTag: IP5BaseSourceCodeLocation;
-		endTag?: IP5BaseSourceCodeLocation;
-	};
+}
+
+export interface IP5NodeSourceLocation extends IP5BaseSourceCodeLocation {
+	startTag: IP5BaseSourceCodeLocation;
+	endTag?: IP5BaseSourceCodeLocation;
 }
 
 export type P5Node = IP5TextNode | IP5TagNode | IP5CommentNode;
+
+export function getSourceLocation(node: IP5TagNode): IP5NodeSourceLocation | null;
+export function getSourceLocation(node: P5Node): IP5BaseSourceCodeLocation | null;
+export function getSourceLocation(node: P5Node): IP5BaseSourceCodeLocation | null {
+	interface NodeWithSourceLocations extends IP5NodeBase {
+		sourceCodeLocation: IP5BaseSourceCodeLocation | null;
+		__location: IP5BaseSourceCodeLocation | null;
+	}
+	const nodeWithLocation = (node as unknown) as NodeWithSourceLocations;
+	return nodeWithLocation.sourceCodeLocation || nodeWithLocation.__location;
+}

--- a/src/analyze/parse/document/text-document/html-document/parse-html-p5/parse-html.ts
+++ b/src/analyze/parse/document/text-document/html-document/parse-html-p5/parse-html.ts
@@ -39,5 +39,5 @@ export function isCommentNode(node: P5Node): node is IP5CommentNode {
  * @param html
  */
 export function parseHtml(html: string): IP5DocumentFragmentNode {
-	return parseFragment(html, { sourceCodeLocationInfo: true });
+	return parseFragment(html, { sourceCodeLocationInfo: true, locationInfo: true });
 }


### PR DESCRIPTION
If supporting both is a maintenance burden, we can solve this
downstream, but so far it seems pretty simple.